### PR TITLE
open file with UTF8 encoding so we Windows-users can evaluate. :-)

### DIFF
--- a/IWSLT2022/scorer.py
+++ b/IWSLT2022/scorer.py
@@ -141,7 +141,7 @@ def predict_formality_label(
     return "OTHER"
 
 def _read_lines(file: str) -> List[str]:
-    with open(file, "r") as file:
+    with open(file, "r", encoding="utf-8") as file:
         raw_text = [line.strip() for line in file.readlines()]
 
     return raw_text


### PR DESCRIPTION
*Description of changes:* see title. By default Windows opens in cp1252, so evaluating e.g., Hindi and Japanese breaks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
